### PR TITLE
Added new Apex switch syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.sfdx/
+.vscode/

--- a/MicroTriggerFramework/main/default/classes/MicroTriggersDispatcher.cls
+++ b/MicroTriggerFramework/main/default/classes/MicroTriggersDispatcher.cls
@@ -77,7 +77,7 @@ public class MicroTriggersDispatcher {
     private List<BaseMicroTrigger> getContextMicroTriggers(String sObjectName) {
         List<BaseMicroTrigger> result = new List<BaseMicroTrigger>();
 
-        switch on Trigger.operationType() {
+        switch on Trigger.operationType {
 
             when BEFORE_INSERT {
                 result = microTriggerLoader.getBeforeInsertMicroTriggers(sObjectName);

--- a/MicroTriggerFramework/main/default/classes/MicroTriggersDispatcher.cls
+++ b/MicroTriggerFramework/main/default/classes/MicroTriggersDispatcher.cls
@@ -76,20 +76,31 @@ public class MicroTriggersDispatcher {
     ********************************************************************************************************/ 
     private List<BaseMicroTrigger> getContextMicroTriggers(String sObjectName) {
         List<BaseMicroTrigger> result = new List<BaseMicroTrigger>();
-        if(Trigger.isBefore && Trigger.isInsert)
-            result = microTriggerLoader.getBeforeInsertMicroTriggers(sObjectName);
-        if(Trigger.isAfter && Trigger.isInsert)
-            result = microTriggerLoader.getAfterInsertMicroTriggers(sObjectName);
-        if(Trigger.isBefore && Trigger.isUpdate)
-            result = microTriggerLoader.getBeforeUpdateMicroTriggers(sObjectName);
-        if(Trigger.isAfter && Trigger.isUpdate)
-            result = microTriggerLoader.getAfterUpdateMicroTriggers(sObjectName);
-        if(Trigger.isBefore && Trigger.isDelete)
-            result = microTriggerLoader.getBeforeDeleteMicroTriggers(sObjectName);
-        if(Trigger.isAfter && Trigger.isDelete)
-            result = microTriggerLoader.getAfterDeleteMicroTriggers(sObjectName);
-        if(Trigger.isAfter && Trigger.isUndelete)
-            result = microTriggerLoader.getAfterUndeleteMicroTriggers(sObjectName);
+
+        switch on Trigger.operationType() {
+
+            when BEFORE_INSERT {
+                result = microTriggerLoader.getBeforeInsertMicroTriggers(sObjectName);
+            }
+            when AFTER_INSERT {
+                result = microTriggerLoader.getAfterInsertMicroTriggers(sObjectName);                
+            }
+            when BEFORE_UPDATE {
+                result = microTriggerLoader.getBeforeUpdateMicroTriggers(sObjectName);                  
+            }
+            when AFTER_UPDATE {
+                result = microTriggerLoader.getAfterUpdateMicroTriggers(sObjectName);                
+            }
+            when BEFORE_DELETE {
+                result = microTriggerLoader.getBeforeDeleteMicroTriggers(sObjectName);                
+            }
+            when AFTER_DELETE {
+                result = microTriggerLoader.getAfterDeleteMicroTriggers(sObjectName);                
+            }
+            when AFTER_UNDELETE {
+                result = microTriggerLoader.getAfterUndeleteMicroTriggers(sObjectName);                
+            }
+        }
 
         return result;
     }

--- a/MicroTriggerFramework/main/default/classes/MicroTriggersDispatcher.cls-meta.xml
+++ b/MicroTriggerFramework/main/default/classes/MicroTriggersDispatcher.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>43.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
As I was looking through some of the code I saw a quick win to incorporate the new apex `switch` feature into the bit where the corresponding microTriggerLoader method is invoked per trigger context. 

The only thing I'm not certain of is that there were several `if` statements (not `if else`). Was this designed for several of the if blocks to be true in a given invocation of `getContextMicroTriggers`? Or was this written this way more for readability? If the former, then the switch will not work. 

In hindsight, I would have submitted the `.gitignore` as a separate PR. If you reject, I'll resubmit it. It will make contributing to this repo in the future easier for other developers. 